### PR TITLE
Enhance achievements

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3,14 +3,13 @@ package client
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/kinduff/csgo_exporter/internal/model"
 
 	log "github.com/sirupsen/logrus"
-
-	"fmt"
 )
 
 type client struct {
@@ -28,9 +27,76 @@ func NewClient() *client {
 	}
 }
 
-func (client *client) DoXMLRequest(config *model.Config, target interface{}) error {
-	url := fmt.Sprintf("https://steamcommunity.com/id/%s/stats/CSGO?xml=1&tab=all&schema=1", config.SteamName)
-	req, err := http.NewRequest("GET", url, nil)
+// DoAPIRequest allows to make requests to the Steam API by standarizing how it receives
+// parameters, and to which endpoint it should do the call.
+func (client *client) DoAPIRequest(endpoint string, config *model.Config, target interface{}) error {
+	req, err := http.NewRequest("GET", getAPIEndpoint(endpoint), nil)
+	if err != nil {
+		log.Fatalf("An error has occurred when creating HTTP request %v", err)
+
+		return err
+	}
+
+	req.URL.RawQuery = getAPIQueryParams(endpoint, config, req)
+
+	log.Infof("Sending HTTP request to %s", req.URL.String())
+
+	resp, err := client.httpClient.Do(req)
+	if err != nil || !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		log.Fatalf("An error has occurred during retrieving statistics %v", err)
+
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func getAPIEndpoint(endpoint string) string {
+	var path string
+	baseUrl := "https://api.steampowered.com"
+
+	switch endpoint {
+	case "achievements":
+		path = "/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v0002"
+	case "stats":
+		path = "/ISteamUserStats/GetUserStatsForGame/v0002"
+	case "id":
+		path = "/ISteamUser/ResolveVanityURL/v0001"
+	case "news":
+		path = "/ISteamNews/GetNewsForApp/v0002"
+	}
+
+	return baseUrl + path
+}
+
+func getAPIQueryParams(endpoint string, config *model.Config, req *http.Request) string {
+	q := req.URL.Query()
+	q.Add("key", config.ApiKey)
+
+	gameIdKey := "appid"
+
+	switch endpoint {
+	case "achievements":
+		gameIdKey = "gameid"
+	case "stats":
+		q.Add("steamid", config.SteamID)
+	case "id":
+		q.Add("vanityurl", config.SteamName)
+	case "news":
+		q.Add("maxlength", "240")
+	}
+
+	q.Add(gameIdKey, "730")
+
+	return q.Encode()
+}
+
+// DoXMLRequest allows to make requests to the Steam web API, this API is not documented,
+// and it's a hacky way to access certain data in XML. It relies on the user having its profile public
+func (client *client) DoXMLRequest(endpoint string, config *model.Config, target interface{}) error {
+	req, err := http.NewRequest("GET", getXMLEndpoint(endpoint, config), nil)
 	if err != nil {
 		log.Fatalf("An error has occurred when creating HTTP request %v", err)
 
@@ -56,68 +122,14 @@ func (client *client) DoXMLRequest(config *model.Config, target interface{}) err
 	return xml.Unmarshal(data, &target)
 }
 
-// DoRequest allows to make requests to the Steam API by standarizing how it receives
-// parameters, and to which endpoint it should do the call.
-func (client *client) DoRequest(endpoint string, config *model.Config, target interface{}) error {
-	req, err := http.NewRequest("GET", getEndpoint(endpoint), nil)
-	if err != nil {
-		log.Fatalf("An error has occurred when creating HTTP request %v", err)
-
-		return err
-	}
-
-	req.URL.RawQuery = getQueryParams(endpoint, config, req)
-
-	log.Infof("Sending HTTP request to %s", req.URL.String())
-
-	resp, err := client.httpClient.Do(req)
-	if err != nil || !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
-		log.Fatalf("An error has occurred during retrieving statistics %v", err)
-
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	return json.NewDecoder(resp.Body).Decode(target)
-}
-
-func getEndpoint(endpoint string) string {
+func getXMLEndpoint(endpoint string, config *model.Config) string {
 	var path string
-	baseUrl := "https://api.steampowered.com"
+	baseUrl := fmt.Sprintf("https://steamcommunity.com/id/%s", config.SteamName)
 
 	switch endpoint {
-	case "achievements":
-		path = "/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v0002"
-	case "stats":
-		path = "/ISteamUserStats/GetUserStatsForGame/v0002"
-	case "id":
-		path = "/ISteamUser/ResolveVanityURL/v0001"
-	case "news":
-		path = "/ISteamNews/GetNewsForApp/v0002"
+	case "achievementsDetails":
+		path = "/stats/CSGO?xml=1"
 	}
 
 	return baseUrl + path
-}
-
-func getQueryParams(endpoint string, config *model.Config, req *http.Request) string {
-	q := req.URL.Query()
-	q.Add("key", config.ApiKey)
-
-	gameIdKey := "appid"
-
-	switch endpoint {
-	case "achievements":
-		gameIdKey = "gameid"
-	case "stats":
-		q.Add("steamid", config.SteamID)
-	case "id":
-		q.Add("vanityurl", config.SteamName)
-	case "news":
-		q.Add("maxlength", "240")
-	}
-
-	q.Add(gameIdKey, "730")
-
-	return q.Encode()
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -124,7 +124,7 @@ func (client *client) DoXMLRequest(endpoint string, config *model.Config, target
 
 func getXMLEndpoint(endpoint string, config *model.Config) string {
 	var path string
-	baseUrl := fmt.Sprintf("https://steamcommunity.com/id/%s", config.SteamName)
+	baseUrl := fmt.Sprintf("https://steamcommunity.com/profiles/%s", config.SteamID)
 
 	switch endpoint {
 	case "achievementsDetails":

--- a/internal/collector/player_stats.go
+++ b/internal/collector/player_stats.go
@@ -54,24 +54,24 @@ func (collector *playerCollector) Collect(ch chan<- prometheus.Metric) {
 
 	if collector.config.SteamID == "" {
 		ResolveVanityUrl := model.ResolveVanityUrl{}
-		if err := client.DoRequest("id", collector.config, &ResolveVanityUrl); err != nil {
+		if err := client.DoAPIRequest("id", collector.config, &ResolveVanityUrl); err != nil {
 			log.Fatal(err)
 		}
 		collector.config.SteamID = ResolveVanityUrl.Response.Steamid
 	}
 
 	playerStats := model.PlayerStats{}
-	if err := client.DoRequest("stats", collector.config, &playerStats); err != nil {
+	if err := client.DoAPIRequest("stats", collector.config, &playerStats); err != nil {
 		log.Fatal(err)
 	}
 
 	archivements := model.Achievements{}
-	if err := client.DoRequest("achievements", collector.config, &archivements); err != nil {
+	if err := client.DoAPIRequest("achievements", collector.config, &archivements); err != nil {
 		log.Fatal(err)
 	}
 
 	news := model.News{}
-	if err := client.DoRequest("news", collector.config, &news); err != nil {
+	if err := client.DoAPIRequest("news", collector.config, &news); err != nil {
 		log.Fatal(err)
 	}
 
@@ -90,7 +90,7 @@ func (collector *playerCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	achievementsDetails := model.AchievementsDetails{}
-	if err := client.DoXMLRequest(collector.config, &achievementsDetails); err != nil {
+	if err := client.DoXMLRequest("achievementsDetails", collector.config, &achievementsDetails); err != nil {
 		log.Fatal(err)
 	}
 

--- a/internal/model/achievements_details.go
+++ b/internal/model/achievements_details.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"encoding/xml"
+)
+
+// AchievementsDetails stores a struct of a XML response to complement the response
+// from the API, since the other response only contains raw data, this adds more detail.
+type AchievementsDetails struct {
+	XMLName         xml.Name `xml:"playerstats"`
+	Text            string   `xml:",chardata"`
+	PrivacyState    string   `xml:"privacyState"`
+	VisibilityState string   `xml:"visibilityState"`
+	Game            struct {
+		Text             string `xml:",chardata"`
+		GameFriendlyName string `xml:"gameFriendlyName"`
+		GameName         string `xml:"gameName"`
+		GameLink         string `xml:"gameLink"`
+		GameIcon         string `xml:"gameIcon"`
+		GameLogo         string `xml:"gameLogo"`
+		GameLogoSmall    string `xml:"gameLogoSmall"`
+	} `xml:"game"`
+	Player struct {
+		Text      string `xml:",chardata"`
+		SteamID64 string `xml:"steamID64"`
+		CustomURL string `xml:"customURL"`
+	} `xml:"player"`
+	Stats struct {
+		Text        string `xml:",chardata"`
+		HoursPlayed string `xml:"hoursPlayed"`
+	} `xml:"stats"`
+	Achievements struct {
+		Text        string `xml:",chardata"`
+		Achievement []struct {
+			Text            string `xml:",chardata"`
+			Closed          string `xml:"closed,attr"`
+			IconClosed      string `xml:"iconClosed"`
+			IconOpen        string `xml:"iconOpen"`
+			Name            string `xml:"name"`
+			Apiname         string `xml:"apiname"`
+			Description     string `xml:"description"`
+			UnlockTimestamp string `xml:"unlockTimestamp"`
+		} `xml:"achievement"`
+	} `xml:"achievements"`
+}

--- a/internal/model/achievements_details.go
+++ b/internal/model/achievements_details.go
@@ -3,9 +3,6 @@ package model
 // AchievementsDetails stores a struct of a XML response to complement the response
 // from the API, since the other response only contains raw data, this adds more detail.
 type AchievementsDetails struct {
-	Stats struct {
-		HoursPlayed string `xml:"hoursPlayed"`
-	} `xml:"stats"`
 	Achievements struct {
 		Achievement []struct {
 			Closed      string `xml:"closed,attr"`

--- a/internal/model/achievements_details.go
+++ b/internal/model/achievements_details.go
@@ -1,45 +1,17 @@
 package model
 
-import (
-	"encoding/xml"
-)
-
 // AchievementsDetails stores a struct of a XML response to complement the response
 // from the API, since the other response only contains raw data, this adds more detail.
 type AchievementsDetails struct {
-	XMLName         xml.Name `xml:"playerstats"`
-	Text            string   `xml:",chardata"`
-	PrivacyState    string   `xml:"privacyState"`
-	VisibilityState string   `xml:"visibilityState"`
-	Game            struct {
-		Text             string `xml:",chardata"`
-		GameFriendlyName string `xml:"gameFriendlyName"`
-		GameName         string `xml:"gameName"`
-		GameLink         string `xml:"gameLink"`
-		GameIcon         string `xml:"gameIcon"`
-		GameLogo         string `xml:"gameLogo"`
-		GameLogoSmall    string `xml:"gameLogoSmall"`
-	} `xml:"game"`
-	Player struct {
-		Text      string `xml:",chardata"`
-		SteamID64 string `xml:"steamID64"`
-		CustomURL string `xml:"customURL"`
-	} `xml:"player"`
 	Stats struct {
-		Text        string `xml:",chardata"`
 		HoursPlayed string `xml:"hoursPlayed"`
 	} `xml:"stats"`
 	Achievements struct {
-		Text        string `xml:",chardata"`
 		Achievement []struct {
-			Text            string `xml:",chardata"`
-			Closed          string `xml:"closed,attr"`
-			IconClosed      string `xml:"iconClosed"`
-			IconOpen        string `xml:"iconOpen"`
-			Name            string `xml:"name"`
-			Apiname         string `xml:"apiname"`
-			Description     string `xml:"description"`
-			UnlockTimestamp string `xml:"unlockTimestamp"`
+			Closed      string `xml:"closed,attr"`
+			Name        string `xml:"name"`
+			Apiname     string `xml:"apiname"`
+			Description string `xml:"description"`
 		} `xml:"achievement"`
 	} `xml:"achievements"`
 }


### PR DESCRIPTION
This PR is part of a series of upgrades I'm doing to the project but using some other endpoints I've found and join the data.

For this particular PR, I'm adding more complete information to player achievements, so we can have `title` and `description`, for example:

```ruby
csgo_achievements_metric{
  title="Wild Gooseman Chase"
  description="As the last living Terrorist, distract a defuser long enough for the bomb to explode",
  name="GOOSE_CHASE",
  player="kinduff",
} 1
``` 

The `name` entry is left for backward compatibility, but it's really the API name for the achievement.