### PR TITLE
Adds playtime_metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This exporter uses environment variables, there are no CLI support for now. The 
 | -------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `csgo_stats_metric`        | All the stats from the player, it includes last_match data, totals per weapon, among other cool things |
 | `csgo_achievements_metric` | All achievements done by the player, with value `1` or `0` for achieved or not                         |
+| `csgo_playtime_metric`     | Hours spent playing the game in minutes in different types, includes stats for each OS                 |
 | `csgo_news_metric`         | The latest news from the CS:GO community, can be used in a table. Value is an epoch                    |
 
 ## Footnotes

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -66,6 +66,8 @@ func getAPIEndpoint(endpoint string) string {
 		path = "/ISteamUser/ResolveVanityURL/v0001"
 	case "news":
 		path = "/ISteamNews/GetNewsForApp/v0002"
+	case "gameInfo":
+		path = "/IPlayerService/GetOwnedGames/v1"
 	}
 
 	return baseUrl + path
@@ -86,6 +88,9 @@ func getAPIQueryParams(endpoint string, config *model.Config, req *http.Request)
 		q.Add("vanityurl", config.SteamName)
 	case "news":
 		q.Add("maxlength", "240")
+	case "gameInfo":
+		q.Add("steamid", config.SteamID)
+		q.Add("appids_filter[0]", "730")
 	}
 
 	q.Add(gameIdKey, "730")

--- a/internal/model/game_info.go
+++ b/internal/model/game_info.go
@@ -1,0 +1,14 @@
+package model
+
+type GameInfo struct {
+	Response struct {
+		Games []struct {
+			Appid                  int `json:"appid"`
+			Playtime2Weeks         int `json:"playtime_2weeks"`
+			PlaytimeForever        int `json:"playtime_forever"`
+			PlaytimeWindowsForever int `json:"playtime_windows_forever"`
+			PlaytimeMacForever     int `json:"playtime_mac_forever"`
+			PlaytimeLinuxForever   int `json:"playtime_linux_forever"`
+		} `json:"games"`
+	} `json:"response"`
+}


### PR DESCRIPTION
Includes `playtime` metric which includes stats in minutes (as a counter) for the time spent playing CSGO

Example:

```ruby
# HELP csgo_playtime_metric Shows the playtime the user has in the game in minutes
# TYPE csgo_playtime_metric counter
csgo_playtime_metric{player="kinduff",type="forever"} 94875
csgo_playtime_metric{player="kinduff",type="last_2_weeks"} 1203
csgo_playtime_metric{player="kinduff",type="linux_forever"} 132
csgo_playtime_metric{player="kinduff",type="mac_forever"} 0
csgo_playtime_metric{player="kinduff",type="windows_forever"} 21504
```