### PR TITLE
Meaningful last match wins/losses

### DIFF
--- a/extra/grafana_dashboard.json
+++ b/extra/grafana_dashboard.json
@@ -397,13 +397,59 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "rgb(0, 0, 0)",
+                "color": "red",
                 "value": null
               }
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Rounds"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(38, 38, 38, 1)",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Wins"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Losses"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 4,
@@ -431,21 +477,21 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "csgo_last_match_metric{type=\"ct_wins\"}",
+          "expr": "csgo_last_match_metric{type=\"wins\"}",
           "hide": false,
           "instant": true,
           "interval": "",
-          "legendFormat": "CT Wins",
+          "legendFormat": "Wins",
           "queryType": "randomWalk",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "csgo_last_match_metric{type=\"t_wins\"}",
+          "expr": "max(csgo_last_match_metric{type=\"rounds\"}) without (type) - max(csgo_last_match_metric{type=\"wins\"}) without (type)",
           "hide": false,
           "instant": true,
           "interval": "",
-          "legendFormat": "T Wins",
+          "legendFormat": "Losses",
           "refId": "B"
         },
         {
@@ -454,7 +500,7 @@
           "hide": false,
           "instant": true,
           "interval": "",
-          "legendFormat": "Rounds",
+          "legendFormat": "Total Rounds",
           "refId": "C"
         }
       ],


### PR DESCRIPTION
Fixes https://github.com/kinduff/csgo_exporter/issues/30

t_wins and ct_wins are nonsense numbers

Also set the wins to be green, losses to be red, and total rounds just gray.

This is how it looks on the light scheme:

![image](https://user-images.githubusercontent.com/1511481/123783394-9a676380-d8d6-11eb-86e8-0557df1beba2.png)

And dark:

![image](https://user-images.githubusercontent.com/1511481/123783450-a9e6ac80-d8d6-11eb-8824-965a27daaf4b.png)

You can see the example here: https://grafana.colega.eu/d/csgo-for-issue-30/csgo-fix-for-issue-30?orgId=2

Although it won't be there forever...

Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>