### PR TITLE
Remove override for Total Rounds

### DIFF
--- a/extra/grafana_dashboard.json
+++ b/extra/grafana_dashboard.json
@@ -390,35 +390,20 @@
         "defaults": {
           "color": {
             "fixedColor": "#222222",
-            "mode": "fixed"
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "text",
                 "value": null
               }
             ]
           }
         },
         "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Total Rounds"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "rgba(38, 38, 38, 1)",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
           {
             "matcher": {
               "id": "byName",


### PR DESCRIPTION
Just a nitpick.

So it inherits the background color mode and looks like fields on the row above, which looks good in both dark and light themes.

Light:

![image](https://user-images.githubusercontent.com/1511481/123785349-b9ff8b80-d8d8-11eb-88dd-0481d5af155e.png)

Dark:

![image](https://user-images.githubusercontent.com/1511481/123785395-c4ba2080-d8d8-11eb-901b-74f8bb616cb0.png)


Signed-off-by: Oleg Zaytsev <mail@olegzaytsev.com>