### PR TITLE
Adjust default scrape interval to 15m

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ $ go build -o csgo_exporter .
 You can use both environment variables or parameters in both the binary or the docker image. If you wish to use parameters, simply invoke the same environment variable but in downcase, or use the flag `--help` for more information.
 
 | Environment variable                   | Description                                                                                         | Default                         | Required |
-|----------------------------------------|-----------------------------------------------------------------------------------------------------|---------------------------------|----------|
+| -------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------- | -------- |
 | `HTTP_PORT`                            | The port the exporter will be running the HTTP server                                               | 7355<sup id="a1">[1](#f1)</sup> |          |
-| `SCRAPE_INTERVAL`                      | Time in natural format to scrap statistics from the CS:GO APIs                                      | `30s`                           |          |
+| `SCRAPE_INTERVAL`                      | Time in natural format to scrap statistics from the CS:GO APIs                                      | `15m`                           |          |
 | `STEAM_API_KEY`                        | Your personal API key from Steam, get one using [this link][steam-api]                              |                                 | Yes      |
 | `STEAM_ID` <sup id="a2">[2](#f2)</sup> | The Steam ID you want to fetch the data from for the player statistics                              |                                 | Yes      |
 | `STEAM_NAME`                           | If you don't want to provide a `STEAM_ID` you can provide your username, see the footnotes          |                                 |          |
@@ -92,7 +92,7 @@ You can use both environment variables or parameters in both the binary or the d
 ## Available Prometheus metrics
 
 | Metric name                  | Description                                                                                            |
-|------------------------------|--------------------------------------------------------------------------------------------------------|
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `csgo_stats_metric`          | All the stats from the player, it includes last_match data, totals per weapon, among other cool things |
 | `csgo_total_kills_metric`    | Total kills from a player per weapon                                                                   |
 | `csgo_total_shots_metric`    | Total shots from a player per weapon                                                                   |

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ func getDefaultConfig() *Config {
 		SteamName:      "",
 		FetchInventory: false,
 		Currency:       "EUR",
-		ScrapeInterval: 30 * time.Second,
+		ScrapeInterval: 15 * 60 * time.Second,
 	}
 }
 


### PR DESCRIPTION
closes #55 
closes #59 

i was running into this reported issue to, as another user reported its related to valve becoming more aggressive due to trading platforms.

i have been running with a scrape interval of 15m for a few weeks now and have had no issue figured id auggest to change the default to match what i've found is working for me.